### PR TITLE
Avoid horizontal scrolling on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ cargo build --release
 Run the server using the command below. The arguments have default values, so you can omit them if the defaults work for your setup.
 
 ```bash
-sudo RUST_LOG=info ./isoserver--server-addr [server address] --handler [handler] --bridge-name [bridge name] --bridge-ip [bridge IP] --subnet [subnet mask] --ns-ip [namespace IP]
+sudo RUST_LOG=info ./isoserver--server-addr [server address] --handler [handler] \
+  --bridge-name [bridge name] --bridge-ip [bridge IP] --subnet [subnet mask] \
+  --ns-ip [namespace IP]
 ```
 
 Values
@@ -58,7 +60,8 @@ This runs a TCP echo server with the default network configuration.
 * UDP Echo Server
 
 ```bash
-sudo RUST_LOG=info ./isoserver --server-addr "0.0.0.0:8081" --handler udp-echo --ns-ip 172.18.0.3
+sudo RUST_LOG=info ./isoserver --server-addr "0.0.0.0:8081" --handler udp-echo \
+  --ns-ip 172.18.0.3
 ```
 
 This starts a UDP echo server, also using default network settings, but with a different namespace IP.


### PR DESCRIPTION
Bash interpreters backslash character as continuing line.